### PR TITLE
fix: Mobile Compatibility issues 

### DIFF
--- a/src/Projects/components/Project.js
+++ b/src/Projects/components/Project.js
@@ -30,7 +30,7 @@ const Project = props => {
 
   const imageColumn =
     projectData.media.type !== "video" ? (
-      <Col sm={{ order: 1, span: 12 }} md={{ order: 0, span: 5 }}>
+      <Col xs={{ order: 1, span: 12 }} md={{ order: 0, span: 5 }}>
         <img
           className="img-fluid"
           src={projectData.media.src}
@@ -40,7 +40,7 @@ const Project = props => {
     ) : (
       <Col
         className="youtube-container"
-        sm={{ order: 1, span: 12 }}
+        xs={{ order: 1, span: 12 }}
         md={{ order: 0, span: 5 }}
       >
         <iframe

--- a/src/Projects/components/Project.js
+++ b/src/Projects/components/Project.js
@@ -71,12 +71,14 @@ const Project = props => {
         {toolsList}
       </ul>
 
-      <ul className="list-inline">
-        <li className="list-inline-item">
-          <strong>Team:</strong>
-        </li>
-        {teamMemberList}
-      </ul>
+      {teamMemberList.length > 0 && (
+        <ul className="list-inline">
+          <li className="list-inline-item">
+            <strong>Team:</strong>
+          </li>
+          {teamMemberList}
+        </ul>
+      )}
 
       <h5 className="text-left">
         <small className="text-muted">{projectData.date}</small>

--- a/src/style/custom.css
+++ b/src/style/custom.css
@@ -150,7 +150,7 @@
 /* Turn off parallax scrolling for tablets and phones.*/
 @media only screen and (max-device-width: 1024px) {
   .parallax {
-    background-attachment: scroll;
+    display: None;
   }
 }
 


### PR DESCRIPTION
closes #14 

### Description: 
1. Hide parallax header on mobile device
2. Horizontal scrolling removed (parallax was causing this)
3. Fixed ordering of images or projects on mobile 
4. (bonus) Only show "Team" in projects if elements exist in the list